### PR TITLE
Use Pavlova to switch from returning dicts to objects

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ mypy = "*"
 
 [packages]
 requests = "*"
+pavlova = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "da7fc9b885754c18f2bafc0675da598548188905a0d0bfdea8e9d52443826aa6"
+            "sha256": "57d671694f666d0fbf2e4b62cd41b91bd6229ddcbe572b297cff3d5e2b54d356"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,13 @@
             ],
             "version": "==3.0.4"
         },
+        "dateparser": {
+            "hashes": [
+                "sha256:42d51be54e74a8e80a4d76d1fa6e4edd997098fce24ad2d94a2eab5ef247193e",
+                "sha256:78124c458c461ea7198faa3c038f6381f37588b84bb42740e91a4cbd260b1d09"
+            ],
+            "version": "==0.7.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -37,20 +44,71 @@
             ],
             "version": "==2.8"
         },
-        "requests": {
+        "pavlova": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:1a5acb53c288dc50b2eeb594dfc07a3af3bb8b0a7066e195d257d05c7c2ee1c8",
+                "sha256:baf36f3f0d5a1cc6dc3829492b3cbd3f0ddfd3601d85ab2a1e47c2ccd457e5d4"
             ],
             "index": "pypi",
-            "version": "==2.21.0"
+            "version": "==0.1.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+            ],
+            "version": "==2019.1"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:2d42791c45853bd6344be2f9ee6ad4ea41112d613a68de86adf11fbd1b9b1f0c",
+                "sha256:30b5cd76b9e079425a3f4871c627428d512c2e557721e2e8a2f98ea884de6a3a",
+                "sha256:5a6e1bba27a438f4dce6d4cd6595f9bb2e5dfa5bded392cf46a77c4a96edb198",
+                "sha256:7474114ab3ae76f2f0261c81345cb09a1eb656d3158eed76743a78ddf4346c02",
+                "sha256:76dbada396d1aa84ba69e83e7bdb49342d7295f2c871332de58ca9b42684583a",
+                "sha256:7e951b0737182d3581a994a056fb825498ec443e236a65623e43415e20ed1e6e",
+                "sha256:a32f5755c5d74349d4e839a45cb0f5919b3fceb7ff9071f8610956839e30375d",
+                "sha256:bfaffc8d4083369a90db796d298d2b0d4553658043e5ffa8a36f8c21a79a9285",
+                "sha256:c5ed448cfa8a51faa6cc3eee59ea6f0da44df699bb5302b36a0f4489977e4f78",
+                "sha256:e33aa03c2866449004de03de877662fb2756a18d64f8b12d6e5608eb851efb7a",
+                "sha256:f58884d0f422c3a02c152f4bd6ed514e9134fc09181556b55280966152ccb02a"
+            ],
+            "version": "==2019.6.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "tzlocal": {
+            "hashes": [
+                "sha256:4ebeb848845ac898da6519b9b31879cf13b6626f7184c496037b818e238f2c4e"
+            ],
+            "version": "==1.5.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.2"
+            "version": "==1.25.3"
         }
     },
     "develop": {
@@ -80,28 +138,27 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:04894d268ba6eab7e093d43107869ad49e7b5ef40d1a94243ea49b352061b200",
-                "sha256:16616ece19daddc586e499a3d2f560302c11f122b9c692bc216e821ae32aa0d0",
-                "sha256:252fdae740964b2d3cdfb3f84dcb4d6247a48a6abe2579e8029ab3be3cdc026c",
-                "sha256:2af80a373af123d0b9f44941a46df67ef0ff7a60f95872412a145f4500a7fc99",
-                "sha256:2c88d0a913229a06282b285f42a31e063c3bf9071ff65c5ea4c12acb6977c6a7",
-                "sha256:2ea99c029ebd4b5a308d915cc7fb95b8e1201d60b065450d5d26deb65d3f2bc1",
-                "sha256:3d2e3ab175fc097d2a51c7a0d3fda442f35ebcc93bb1d7bd9b95ad893e44c04d",
-                "sha256:4766dd695548a15ee766927bf883fb90c6ac8321be5a60c141f18628fb7f8da8",
-                "sha256:56b6978798502ef66625a2e0f80cf923da64e328da8bbe16c1ff928c70c873de",
-                "sha256:5cddb6f8bce14325b2863f9d5ac5c51e07b71b462361fd815d1d7706d3a9d682",
-                "sha256:644ee788222d81555af543b70a1098f2025db38eaa99226f3a75a6854924d4db",
-                "sha256:64cf762049fc4775efe6b27161467e76d0ba145862802a65eefc8879086fc6f8",
-                "sha256:68c362848d9fb71d3c3e5f43c09974a0ae319144634e7a47db62f0f2a54a7fa7",
-                "sha256:6c1f3c6f6635e611d58e467bf4371883568f0de9ccc4606f17048142dec14a1f",
-                "sha256:b213d4a02eec4ddf622f4d2fbc539f062af3788d1f332f028a2e19c42da53f15",
-                "sha256:bb27d4e7805a7de0e35bd0cb1411bc85f807968b2b0539597a49a23b00a622ae",
-                "sha256:c9d414512eaa417aadae7758bc118868cd2396b0e6138c1dd4fda96679c079d3",
-                "sha256:f0937165d1e25477b01081c4763d2d9cdc3b18af69cb259dd4f640c9b900fe5e",
-                "sha256:fb96a6e2c11059ecf84e6741a319f93f683e440e341d4489c9b161eca251cf2a",
-                "sha256:fc71d2d6ae56a091a8d94f33ec9d0f2001d1cb1db423d8b4355debfe9ce689b7"
+                "sha256:132eae51d6ef3ff4a8c47c393a4ef5ebf0d1aecc96880eb5d6c8ceab7017cc9b",
+                "sha256:18141c1484ab8784006c839be8b985cfc82a2e9725837b0ecfa0203f71c4e39d",
+                "sha256:2baf617f5bbbfe73fd8846463f5aeafc912b5ee247f410700245d68525ec584a",
+                "sha256:3d90063f2cbbe39177e9b4d888e45777012652d6110156845b828908c51ae462",
+                "sha256:4304b2218b842d610aa1a1d87e1dc9559597969acc62ce717ee4dfeaa44d7eee",
+                "sha256:4983ede548ffc3541bae49a82675996497348e55bafd1554dc4e4a5d6eda541a",
+                "sha256:5315f4509c1476718a4825f45a203b82d7fdf2a6f5f0c8f166435975b1c9f7d4",
+                "sha256:6cdfb1b49d5345f7c2b90d638822d16ba62dc82f7616e9b4caa10b72f3f16649",
+                "sha256:7b325f12635598c604690efd7a0197d0b94b7d7778498e76e0710cd582fd1c7a",
+                "sha256:8d3b0e3b8626615826f9a626548057c5275a9733512b137984a68ba1598d3d2f",
+                "sha256:8f8631160c79f53081bd23446525db0bc4c5616f78d04021e6e434b286493fd7",
+                "sha256:912de10965f3dc89da23936f1cc4ed60764f712e5fa603a09dd904f88c996760",
+                "sha256:b010c07b975fe853c65d7bbe9d4ac62f1c69086750a574f6292597763781ba18",
+                "sha256:c908c10505904c48081a5415a1e295d8403e353e0c14c42b6d67f8f97fae6616",
+                "sha256:c94dd3807c0c0610f7c76f078119f4ea48235a953512752b9175f9f98f5ae2bd",
+                "sha256:ce65dee7594a84c466e79d7fb7d3303e7295d16a83c22c7c4037071b059e2c21",
+                "sha256:eaa9cfcb221a8a4c2889be6f93da141ac777eb8819f077e1d09fb12d00a09a93",
+                "sha256:f3376bc31bad66d46d44b4e6522c5c21976bf9bca4ef5987bb2bf727f4506cbb",
+                "sha256:f9202fa138544e13a4ec1a6792c35834250a85958fde1251b6a22e07d1260ae7"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         }
     }
 }

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -207,6 +207,33 @@ class Group:
     unused_states  : List[str]
     unused_tags    : List[str]
 
+@dataclass
+class Submission:
+    abstract        : str
+    access_key      : str
+    auth_key        : str
+    authors         : str
+    checks          : List[str]
+    document_date   : str
+    draft           : str
+    file_size       : int
+    file_types      : str
+    first_two_pages : str
+    group           : str
+    id              : int
+    name            : str
+    note            : str
+    pages           : int
+    remote_ip       : str
+    replaces        : str
+    resource_uri    : str
+    rev             : str
+    state           : str
+    submission_date : str
+    submitter       : str
+    title           : str
+    words           : Optional[int]
+    
 # =================================================================================================================================
 # A class to represent the datatracker:
 
@@ -541,16 +568,22 @@ class DataTracker:
     #   https://datatracker.ietf.org/api/v1/doc/addedmessageevent/
     #   https://datatracker.ietf.org/api/v1/doc/editedauthorsdocevent/
 
-    def submission(self, submission):
-        # FIXME: add documentation
+    def submission(self, submission_uri):
         """
-        Returns a JSON object giving information about a document submission.
+        Information about a document submission.
+
+        Parameters:
+           submission_uri -- A submission URI of the form /api/v1/submit/submission/2402/                             
+
+        Returns:
+            A Submission object
         """
-        assert submission.startswith("/api/v1/doc/document/")
-        assert submission.endswith("/")
-        response = self.session.get(self.base_url + submission, verify=True)
+
+        assert submission_uri.startswith("/api/v1/submit/submission/")
+        assert submission_uri.endswith("/")
+        response = self.session.get(self.base_url + submission_uri, verify=True)
         if response.status_code == 200:
-            return response.json()
+            return Pavlova().from_mapping(response.json(), Submission)
         else:
             return None
 
@@ -1001,8 +1034,32 @@ class TestDatatracker(unittest.TestCase):
         self.assertEqual(st[22].slug, 'shepwrit')
 
     def test_submission(self):
-        # FIXME: implement tests
-        raise NotImplementedError
+        dt = DataTracker()
+        s  = dt.submission("/api/v1/submit/submission/2402/")
+        self.assertEqual(s.abstract,        "Internet technical specifications often need to define a formal\nsyntax.  Over the years, a modified version of Backus-Naur Form\n(BNF), called Augmented BNF (ABNF), has been popular among many\nInternet specifications.  The current specification documents ABNF.\nIt balances compactness and simplicity, with reasonable\nrepresentational power.  The differences between standard BNF and\nABNF involve naming rules, repetition, alternatives, order-\nindependence, and value ranges.  This specification also supplies\nadditional rule definitions and encoding for a core lexical analyzer\nof the type common to several Internet specifications.")
+        self.assertEqual(s.access_key,      "f77d08da6da54f3cbecca13d31646be8")
+        self.assertEqual(s.auth_key,        "fMm6hur5dJ7gV58x5SE0vkHUoDOrSuSF")
+        self.assertEqual(s.authors,         "[{u'email': u'dcrocker@bbiw.net', u'name': u'Dave Crocker'}, {u'email': u'paul.overell@thus.net', u'name': u'Paul Overell'}]")
+        self.assertEqual(s.checks,          ["/api/v1/submit/submissioncheck/386/"])
+        self.assertEqual(s.document_date,   "2007-10-09")
+        self.assertEqual(s.draft,           "/api/v1/doc/document/draft-crocker-rfc4234bis/")
+        self.assertEqual(s.file_size,       27651)
+        self.assertEqual(s.file_types,      ".txt,.xml,.pdf")
+        self.assertEqual(s.first_two_pages, "\n\n\nNetwork Working Group                                    D. Crocker, Ed.\nInternet-Draft                               Brandenburg InternetWorking\nObsoletes: 4234 (if approved)                                 P. Overell\nIntended status: Standards Track                               THUS plc.\nExpires: April 11, 2008                                  October 9, 2007\n\n\n             Augmented BNF for Syntax Specifications: ABNF\n                      draft-crocker-rfc4234bis-01\n\nStatus of this Memo\n\n   By submitting this Internet-Draft, each author represents that any\n   applicable patent or other IPR claims of which he or she is aware\n   have been or will be disclosed, and any of which he or she becomes\n   aware will be disclosed, in accordance with Section 6 of BCP 79.\n\n   Internet-Drafts are working documents of the Internet Engineering\n   Task Force (IETF), its areas, and its working groups.  Note that\n   other groups may also distribute working documents as Internet-\n   Drafts.\n\n   Internet-Drafts are draft documents valid for a maximum of six months\n   and may be updated, replaced, or obsoleted by other documents at any\n   time.  It is inappropriate to use Internet-Drafts as reference\n   material or to cite them other than as \"work in progress.\"\n\n   The list of current Internet-Drafts can be accessed at\n   http://www.ietf.org/ietf/1id-abstracts.txt.\n\n   The list of Internet-Draft Shadow Directories can be accessed at\n   http://www.ietf.org/shadow.html.\n\n   This Internet-Draft will expire on April 11, 2008.\n\nCopyright Notice\n\n   Copyright (C) The IETF Trust (2007).\n\nAbstract\n\n   Internet technical specifications often need to define a formal\n   syntax.  Over the years, a modified version of Backus-Naur Form\n   (BNF), called Augmented BNF (ABNF), has been popular among many\n   Internet specifications.  The current specification documents ABNF.\n   It balances compactness and simplicity, with reasonable\n   representational power.  The differences between standard BNF and\n   ABNF involve naming rules, repetition, alternatives, order-\n\n\n\nCrocker & Overell        Expires April 11, 2008                 [page 1]\n\nInternet-Draft                    ABNF                      October 2007\n\n\n   independence, and value ranges.  This specification also supplies\n   additional rule definitions and encoding for a core lexical analyzer\n   of the type common to several Internet specifications.\n\n\nTable of Contents\n\n   1.  INTRODUCTION . . . . . . . . . . . . . . . . . . . . . . . . .  3\n   2.  RULE DEFINITION  . . . . . . . . . . . . . . . . . . . . . . .  3\n     2.1.  Rule Naming  . . . . . . . . . . . . . . . . . . . . . . .  3\n     2.2.  Rule Form  . . . . . . . . . . . . . . . . . . . . . . . .  4\n     2.3.  Terminal Values  . . . . . . . . . . . . . . . . . . . . .  4\n     2.4.  External Encodings . . . . . . . . . . . . . . . . . . . .  5\n   3.  OPERATORS  . . . . . . . . . . . . . . . . . . . . . . . . . .  6\n     3.1.  Concatenation:  Rule1 Rule2  . . . . . . . . . . . . . . .  6\n     3.2.  Alternatives:  Rule1 / Rule2 . . . . . . . . . . . . . . .  6\n     3.3.  Incremental Alternatives: Rule1 =/ Rule2 . . . . . . . . .  7\n     3.4.  Value Range Alternatives:  %c##-## . . . . . . . . . . . .  7\n     3.5.  Sequence Group:  (Rule1 Rule2) . . . . . . . . . . . . . .  8\n     3.6.  Variable Repetition:  *Rule  . . . . . . . . . . . . . . .  8\n     3.7.  Specific Repetition:  nRule  . . . . . . . . . . . . . . .  9\n     3.8.  Optional Sequence:  [RULE] . . . . . . . . . . . . . . . .  9\n     3.9.  Comment:  ; Comment  . . . . . . . . . . . . . . . . . . .  9\n     3.10. Operator Precedence  . . . . . . . . . . . . . . . . . . .  9\n   4.  ABNF DEFINITION OF ABNF  . . . . . . . . . . . . . . . . . . . 10\n   5.  SECURITY CONSIDERATIONS  . . . . . . . . . . . . . . . . . . . 11\n   6.  References . . . . . . . . . . . . . . . . . . . . . . . . . . 11\n     6.1.  Normative References . . . . . . . . . . . . . . . . . . . 11\n     6.2.  Informative References . . . . . . . . . . . . . . . . . . 12\n   Appendix A.  ACKNOWLEDGEMENTS  . . . . . . . . . . . . . . . . . . 12\n   Appendix B.  CORE ABNF OF ABNF . . . . . . . . . . . . . . . . . . 13\n     B.1.  Core Rules . . . . . . . . . . . . . . . . . . . . . . . . 13\n     B.2.  Common Encoding  . . . . . . . . . . . . . . . . . . . . . 14\n   Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . . . 14\n   Intellectual Property and Copyright Statements . . . . . . . . . . 16\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nCrocker & Overell        Expires April 11, 2008                 [page 2]")
+        self.assertEqual(s.group,           "/api/v1/group/group/1027/")
+        self.assertEqual(s.id,              2402)
+        self.assertEqual(s.name,            "draft-crocker-rfc4234bis")
+        self.assertEqual(s.note,            "")
+        self.assertEqual(s.pages,           13)
+        self.assertEqual(s.remote_ip,       "72.255.3.179")
+        self.assertEqual(s.replaces,        "")
+        self.assertEqual(s.resource_uri,    "/api/v1/submit/submission/2402/")
+        self.assertEqual(s.rev,             "01")
+        self.assertEqual(s.state,           "/api/v1/name/draftsubmissionstatename/posted/")
+        self.assertEqual(s.submission_date, "2007-10-09")
+        self.assertEqual(s.submitter,       "Dave Crocker")
+        self.assertEqual(s.title,           "Augmented BNF for Syntax Specifications: ABNF")
+        self.assertEqual(s.words,           None)
 
     def test_document_type(self):
         dt      = DataTracker()

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -56,7 +56,7 @@ import unittest
 import re
 
 # =================================================================================================================================
-# A class to represent a Person:
+# Classes to represent the JSON-serialised objects returned by the Datatracker API:
 
 @dataclass
 class Person:
@@ -72,9 +72,6 @@ class Person:
     photo_thumb     : str
     biography       : str
     consent         : bool
-
-# =================================================================================================================================
-# A class to represent an Email:
 
 @dataclass
 class Email:
@@ -118,14 +115,7 @@ class DataTracker:
            email : the email address to lookup
 
         Returns:
-            A Dict containing the following fields:
-                "resource_uri" -- A URI representing this resource
-                "address"      -- The requested email address
-                "person"       -- A URI suitable for use with the person() method
-                "time"         -- 
-                "origin"       -- 
-                "primary"      -- True if this is the primary email address of the person
-                "active"       -- True if this is an active email address
+            An Email object
         """
         response = self.session.get(self.base_url + "/api/v1/person/email/" + email + "/", verify=True)
         if response.status_code == 200:

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -162,6 +162,12 @@ class State:
     type         : str
     used         : bool
 
+@dataclass
+class StateType:
+    resource_uri : str
+    label        : str
+    slug         : str
+
 # =================================================================================================================================
 # A class to represent the datatracker:
 
@@ -440,7 +446,7 @@ class DataTracker:
             objs = r.json()['objects']
             api_url = meta['next']
             for obj in objs:
-                yield obj
+                yield Pavlova().from_mapping(obj, StateType)
 
 
     #   https://datatracker.ietf.org/api/v1/doc/docevent/                        - list of document events
@@ -919,29 +925,29 @@ class TestDatatracker(unittest.TestCase):
         dt = DataTracker()
         st = list(dt.document_state_types())
         self.assertEqual(len(st), 23)
-        self.assertEqual(st[ 0]["slug"], 'draft')
-        self.assertEqual(st[ 1]["slug"], 'draft-iesg')
-        self.assertEqual(st[ 2]["slug"], 'draft-iana')
-        self.assertEqual(st[ 3]["slug"], 'draft-rfceditor')
-        self.assertEqual(st[ 4]["slug"], 'draft-stream-ietf')
-        self.assertEqual(st[ 5]["slug"], 'draft-stream-irtf')
-        self.assertEqual(st[ 6]["slug"], 'draft-stream-ise')
-        self.assertEqual(st[ 7]["slug"], 'draft-stream-iab')
-        self.assertEqual(st[ 8]["slug"], 'slides')
-        self.assertEqual(st[ 9]["slug"], 'minutes')
-        self.assertEqual(st[10]["slug"], 'agenda')
-        self.assertEqual(st[11]["slug"], 'liai-att')
-        self.assertEqual(st[12]["slug"], 'charter')
-        self.assertEqual(st[13]["slug"], 'conflrev')
-        self.assertEqual(st[14]["slug"], 'draft-iana-action')
-        self.assertEqual(st[15]["slug"], 'draft-iana-review')
-        self.assertEqual(st[16]["slug"], 'statchg')
-        self.assertEqual(st[17]["slug"], 'recording')
-        self.assertEqual(st[18]["slug"], 'bluesheets')
-        self.assertEqual(st[19]["slug"], 'reuse_policy')
-        self.assertEqual(st[20]["slug"], 'review')
-        self.assertEqual(st[21]["slug"], 'liaison')
-        self.assertEqual(st[22]["slug"], 'shepwrit')
+        self.assertEqual(st[ 0].slug, 'draft')
+        self.assertEqual(st[ 1].slug, 'draft-iesg')
+        self.assertEqual(st[ 2].slug, 'draft-iana')
+        self.assertEqual(st[ 3].slug, 'draft-rfceditor')
+        self.assertEqual(st[ 4].slug, 'draft-stream-ietf')
+        self.assertEqual(st[ 5].slug, 'draft-stream-irtf')
+        self.assertEqual(st[ 6].slug, 'draft-stream-ise')
+        self.assertEqual(st[ 7].slug, 'draft-stream-iab')
+        self.assertEqual(st[ 8].slug, 'slides')
+        self.assertEqual(st[ 9].slug, 'minutes')
+        self.assertEqual(st[10].slug, 'agenda')
+        self.assertEqual(st[11].slug, 'liai-att')
+        self.assertEqual(st[12].slug, 'charter')
+        self.assertEqual(st[13].slug, 'conflrev')
+        self.assertEqual(st[14].slug, 'draft-iana-action')
+        self.assertEqual(st[15].slug, 'draft-iana-review')
+        self.assertEqual(st[16].slug, 'statchg')
+        self.assertEqual(st[17].slug, 'recording')
+        self.assertEqual(st[18].slug, 'bluesheets')
+        self.assertEqual(st[19].slug, 'reuse_policy')
+        self.assertEqual(st[20].slug, 'review')
+        self.assertEqual(st[21].slug, 'liaison')
+        self.assertEqual(st[22].slug, 'shepwrit')
 
     def test_submission(self):
         # FIXME: implement tests

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -178,6 +178,15 @@ class DocumentType:
     desc         : str
     order        : int
 
+@dataclass
+class Stream:
+    resource_uri : str
+    name         : str
+    desc         : str
+    used         : bool
+    slug         : str
+    order        : int
+
 # =================================================================================================================================
 # A class to represent the datatracker:
 
@@ -587,18 +596,12 @@ class DataTracker:
             stream_uri : a URI of the form, e.g., "/api/v1/name/streamname/.../"
 
         Returns:
-            A Dict containing the following fields:
-                "resource_uri" -- A URI representing this resource
-                "name"         -- The stream name
-                "desc"         -- A description of hte stream
-                "used"         -- True is this stream is used
-                "slug"         --
-                "order"        -- 
+            A Stream object
         """
         assert stream_uri.startswith("/api/v1/name/streamname/") and stream_uri.endswith("/")
         response = self.session.get(self.base_url + stream_uri, verify=True)
         if response.status_code == 200:
-            return response.json()
+            return Pavlova().from_mapping(response.json(), Stream)
         else:
             return None
 
@@ -611,7 +614,7 @@ class DataTracker:
             none
 
         Returns:
-            A sequence of dicts, as returned by stream()
+            A sequence of Stream objects, as returned by stream()
         """
         url = "/api/v1/name/streamname/"
         while url != None:
@@ -620,7 +623,7 @@ class DataTracker:
             objs = r.json()['objects']
             url  = meta['next']
             for obj in objs:
-                yield obj
+                yield Pavlova().from_mapping(obj, Stream)
 
 
     # Datatracker API endpoints returning information about working groups:
@@ -977,22 +980,22 @@ class TestDatatracker(unittest.TestCase):
     def test_stream(self):
         dt     = DataTracker()
         stream = dt.stream("/api/v1/name/streamname/irtf/")
-        self.assertEqual(stream["desc"],         "IRTF Stream")
-        self.assertEqual(stream["name"],         "IRTF")
-        self.assertEqual(stream["order"],        3)
-        self.assertEqual(stream["resource_uri"], "/api/v1/name/streamname/irtf/")
-        self.assertEqual(stream["slug"],         "irtf")
-        self.assertEqual(stream["used"],         True)
+        self.assertEqual(stream.desc,         "IRTF Stream")
+        self.assertEqual(stream.name,         "IRTF")
+        self.assertEqual(stream.order,        3)
+        self.assertEqual(stream.resource_uri, "/api/v1/name/streamname/irtf/")
+        self.assertEqual(stream.slug,         "irtf")
+        self.assertEqual(stream.used,         True)
 
     def test_streams(self):
         dt      = DataTracker()
         streams = list(dt.streams())
         self.assertEqual(len(streams), 5)
-        self.assertEqual(streams[ 0]["slug"], "ietf")
-        self.assertEqual(streams[ 1]["slug"], "ise")
-        self.assertEqual(streams[ 2]["slug"], "irtf")
-        self.assertEqual(streams[ 3]["slug"], "iab")
-        self.assertEqual(streams[ 4]["slug"], "legacy")
+        self.assertEqual(streams[ 0].slug, "ietf")
+        self.assertEqual(streams[ 1].slug, "ise")
+        self.assertEqual(streams[ 2].slug, "irtf")
+        self.assertEqual(streams[ 3].slug, "iab")
+        self.assertEqual(streams[ 4].slug, "legacy")
 
     def test_group(self):
         # FIXME: implement tests

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -396,7 +396,7 @@ class DataTracker:
             rfc -- The RFC to lookup, in the form "rfc3550" or "RFC3550"
 
         Returns:
-            A Dict containing the same fields as the document() method.
+            A Document object
         """
         assert rfc.lower().startswith("rfc")
         url  = self.base_url + "/api/v1/doc/docalias/" + rfc.lower() + "/"

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -725,8 +725,13 @@ class DataTracker:
     #   https://datatracker.ietf.org/api/v1/group/groupstatetransitions                - ???
 
     def group(self, group_id):
-        # FIXME: implement this
-        raise NotImplementedError
+        # FIXME: add documentation
+        api_url  = "/api/v1/group/group/%d/" % (group_id) 
+        response = self.session.get(self.base_url + api_url, verify=True)
+        if response.status_code == 200:
+            return Pavlova().from_mapping(response.json(), Group)
+        else:
+            return None
 
     def group_from_acronym(self, acronym):
         # FIXME: add documentation
@@ -1111,8 +1116,25 @@ class TestDatatracker(unittest.TestCase):
         self.assertEqual(streams[ 4].slug, "legacy")
 
     def test_group(self):
-        # FIXME: implement tests
-        raise NotImplementedError
+        dt = DataTracker()
+        group = dt.group(941)
+        self.assertEqual(group.acronym,        "avt")
+        self.assertEqual(group.ad,             None)
+        self.assertEqual(group.charter,        "/api/v1/doc/document/charter-ietf-avt/")
+        self.assertEqual(group.comments,       "")
+        self.assertEqual(group.description,    "\n  The Audio/Video Transport Working Group was formed to specify a protocol \n  for real-time transmission of audio and video over unicast and multicast \n  UDP/IP. This is the Real-time Transport Protocol, RTP, along with its \n  associated profiles and payload formats.")
+        self.assertEqual(group.id,             941)
+        self.assertEqual(group.list_archive,   "https://mailarchive.ietf.org/arch/search/?email_list=avt")
+        self.assertEqual(group.list_email,     "avt@ietf.org")
+        self.assertEqual(group.list_subscribe, "https://www.ietf.org/mailman/listinfo/avt")
+        self.assertEqual(group.name,           "Audio/Video Transport")
+        self.assertEqual(group.parent,         "/api/v1/group/group/1683/")
+        self.assertEqual(group.resource_uri,   "/api/v1/group/group/941/")
+        self.assertEqual(group.state,          "/api/v1/name/groupstatename/conclude/")
+        self.assertEqual(group.time,           "2011-12-09T12:00:00")
+        self.assertEqual(group.type,           "/api/v1/name/grouptypename/wg/")
+        self.assertEqual(group.unused_states,  [])
+        self.assertEqual(group.unused_tags,    [])
 
     def test_group_from_acronym(self):
         dt = DataTracker()
@@ -1124,6 +1146,7 @@ class TestDatatracker(unittest.TestCase):
         raise NotImplementedError
 
 if __name__ == '__main__':
+    #TestDatatracker().test_group()
     unittest.main()
 
 # =================================================================================================================================

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -408,8 +408,22 @@ class DataTracker:
 
 
     def document_from_bcp(self, bcp: str):
-        # FIXME: implement this
-        raise NotImplementedError
+        """
+        Returns the document that became the specified BCP.
+
+        Parameters:
+            rfc -- The RFC to lookup, in the form "bcp205" or "BCP205"
+
+        Returns:
+            A Document object
+        """
+        assert bcp.lower().startswith("bcp")
+        url  = self.base_url + "/api/v1/doc/docalias/" + bcp.lower() + "/"
+        response = self.session.get(url, verify=True)
+        if response.status_code == 200:
+            return self.document(response.json()['document'])
+        else:
+            return None
 
 
     def document_from_std(self, std: str):
@@ -900,8 +914,9 @@ class TestDatatracker(unittest.TestCase):
         self.assertEqual(d.resource_uri, "/api/v1/doc/document/draft-ietf-avt-rtp-new/")
 
     def test_document_from_bcp(self):
-        # FIXME: implement tests
-        raise NotImplementedError
+        dt = DataTracker()
+        d  = dt.document_from_bcp("bcp205")
+        self.assertEqual(d.resource_uri, "/api/v1/doc/document/draft-sheffer-rfc6982bis/")
 
     def test_document_from_std(self):
         # FIXME: implement tests

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -681,7 +681,7 @@ class DataTracker:
         # FIXME: add documentation
         # FIXME: no tests for this
         """
-        A generator that returns JSON objects representing all groups recorded
+        A generator that returns Group objects representing all groups recorded
         in the datatracker. The since and until parameters can be used to contrain
         the output to only entries with timestamps in a particular time range.
         If provided, name_contains filters based on the whether the name field

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -168,6 +168,16 @@ class StateType:
     label        : str
     slug         : str
 
+@dataclass
+class DocumentType:
+    resource_uri : str
+    name         : str
+    used         : bool
+    prefix       : str
+    slug         : str
+    desc         : str
+    order        : int
+
 # =================================================================================================================================
 # A class to represent the datatracker:
 
@@ -539,19 +549,12 @@ class DataTracker:
                           return from a call to document().
 
         Returns:
-            A Dict containing the following fields:
-                "resource_uri" -- A URI representing this resource
-                "name"         -- The name of the document type
-                "used"         -- True is this document type is used
-                "prefix"       --
-                "slug"         --
-                "desc"         -- (unused)
-                "order"        -- (unused)
+            A DocumentType object
         """
         assert doctype_uri.startswith("/api/v1/name/doctypename/") and doctype_uri.endswith("/")
         response = self.session.get(self.base_url + doctype_uri, verify=True)
         if response.status_code == 200:
-            return response.json()
+            return Pavlova().from_mapping(response.json(), DocumentType)
         else:
             return None
 
@@ -564,7 +567,7 @@ class DataTracker:
             none
 
         Returns:
-            A sequence of dicts, as returned by document_type()
+            A sequence of DocumentType objects, as returned by document_type()
         """
         url = "/api/v1/name/doctypename/"
         while url != None:
@@ -573,7 +576,7 @@ class DataTracker:
             objs = r.json()['objects']
             url  = meta['next']
             for obj in objs:
-                yield obj
+                yield Pavlova().from_mapping(obj, DocumentType)
 
 
     def stream(self, stream_uri: str):
@@ -957,19 +960,19 @@ class TestDatatracker(unittest.TestCase):
         dt    = DataTracker()
         types = list(dt.document_types())
         self.assertEqual(len(types), 13)
-        self.assertEqual(types[ 0]["slug"], "agenda")
-        self.assertEqual(types[ 1]["slug"], "bluesheets")
-        self.assertEqual(types[ 2]["slug"], "charter")
-        self.assertEqual(types[ 3]["slug"], "conflrev")
-        self.assertEqual(types[ 4]["slug"], "draft")
-        self.assertEqual(types[ 5]["slug"], "liaison")
-        self.assertEqual(types[ 6]["slug"], "liai-att")
-        self.assertEqual(types[ 7]["slug"], "minutes")
-        self.assertEqual(types[ 8]["slug"], "recording")
-        self.assertEqual(types[ 9]["slug"], "review")
-        self.assertEqual(types[10]["slug"], "shepwrit")
-        self.assertEqual(types[11]["slug"], "slides")
-        self.assertEqual(types[12]["slug"], "statchg")
+        self.assertEqual(types[ 0].slug, "agenda")
+        self.assertEqual(types[ 1].slug, "bluesheets")
+        self.assertEqual(types[ 2].slug, "charter")
+        self.assertEqual(types[ 3].slug, "conflrev")
+        self.assertEqual(types[ 4].slug, "draft")
+        self.assertEqual(types[ 5].slug, "liaison")
+        self.assertEqual(types[ 6].slug, "liai-att")
+        self.assertEqual(types[ 7].slug, "minutes")
+        self.assertEqual(types[ 8].slug, "recording")
+        self.assertEqual(types[ 9].slug, "review")
+        self.assertEqual(types[10].slug, "shepwrit")
+        self.assertEqual(types[11].slug, "slides")
+        self.assertEqual(types[12].slug, "statchg")
 
     def test_stream(self):
         dt     = DataTracker()

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -187,6 +187,26 @@ class Stream:
     slug         : str
     order        : int
 
+@dataclass
+class Group:
+    acronym        : str
+    ad             : Optional[str]
+    charter        : str
+    comments       : str
+    description    : str
+    id             : int
+    list_archive   : str
+    list_email     : str
+    list_subscribe : str
+    name           : str
+    parent         : str
+    resource_uri   : str
+    state          : str
+    time           : str
+    type           : str
+    unused_states  : List[str]
+    unused_tags    : List[str]
+
 # =================================================================================================================================
 # A class to represent the datatracker:
 
@@ -653,7 +673,7 @@ class DataTracker:
         api_url  = "/api/v1/group/group/?acronym=" + acronym
         response = self.session.get(self.base_url + api_url, verify=True)
         if response.status_code == 200:
-            return response.json()["objects"][0]
+            return Pavlova().from_mapping(response.json()["objects"][0], Group)
         else:
             return None
 
@@ -676,7 +696,7 @@ class DataTracker:
             objs = r.json()['objects']
             api_url = meta['next']
             for obj in objs:
-                yield obj
+                yield Pavlova().from_mapping(obj, Group)
 
     # Datatracker API endpoints returning information about meetings:
     #   https://datatracker.ietf.org/api/v1/meeting/meeting/                        - list of meetings
@@ -1004,7 +1024,7 @@ class TestDatatracker(unittest.TestCase):
     def test_group_from_acronym(self):
         dt = DataTracker()
         group = dt.group_from_acronym("avt")
-        self.assertEqual(group['id'], 941)
+        self.assertEqual(group.id, 941)
 
     def test_groups(self):
         # FIXME: implement tests

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -150,6 +150,17 @@ class Document:
             raise NotImplementedError
         return document_url
 
+@dataclass
+class State:
+    id           : int
+    resource_uri : str
+    desc         : str
+    name         : str
+    next_states  : List[str]
+    order        : int
+    slug         : str
+    type         : str
+    used         : bool
 
 # =================================================================================================================================
 # A class to represent the datatracker:
@@ -374,21 +385,12 @@ class DataTracker:
                         in the states entry of the dict returned by document()
 
         Returns:
-            A Dict containing the following fields:
-              id           -- An identifier for the state
-              resource_uri -- The URI representing this state
-              desc         -- A description of the state
-              name         -- The name of the state
-              next_states  -- A List of URIs representing possible next states for the document
-              order        -- 
-              slug         -- Short name
-              type         -- A URI as returned by document_state_types()
-              used         -- True if this state is used in the datatracker
+            A State object
         """
         assert state_uri.startswith("/api/v1/doc/state/") and state_uri.endswith("/")
         response = self.session.get(self.base_url + state_uri, verify=True)
         if response.status_code == 200:
-            return response.json()
+            return Pavlova().from_mapping(response.json(), State)
         else:
             return None
 
@@ -403,7 +405,7 @@ class DataTracker:
                         to that particular state type.
 
         Returns:
-            A sequence of dicts, as returned by document_state()
+            A sequence of Document objects, as returned by document_state()
         """
         api_url   = "/api/v1/doc/state/"
         if statetype is not None:
@@ -414,7 +416,7 @@ class DataTracker:
             objs = r.json()['objects']
             api_url = meta['next']
             for obj in objs:
-                yield obj
+                yield Pavlova().from_mapping(obj, State)
 
 
     def document_state_types(self):
@@ -880,38 +882,38 @@ class TestDatatracker(unittest.TestCase):
     def test_document_state(self):
         dt = DataTracker()
         s = dt.document_state('/api/v1/doc/state/7/')
-        self.assertEqual(s['desc'],         'The ID has been published as an RFC.')
-        self.assertEqual(s['id'],           7)
-        self.assertEqual(s['name'],         'RFC Published')
-        self.assertEqual(s['next_states'],  ['/api/v1/doc/state/8/'])
-        self.assertEqual(s['order'],        32)
-        self.assertEqual(s['resource_uri'], '/api/v1/doc/state/7/')
-        self.assertEqual(s['slug'],         'pub')
-        self.assertEqual(s['type'],         '/api/v1/doc/statetype/draft-iesg/')
-        self.assertEqual(s['used'],         True)
+        self.assertEqual(s.desc,         'The ID has been published as an RFC.')
+        self.assertEqual(s.id,           7)
+        self.assertEqual(s.name,         'RFC Published')
+        self.assertEqual(s.next_states,  ['/api/v1/doc/state/8/'])
+        self.assertEqual(s.order,        32)
+        self.assertEqual(s.resource_uri, '/api/v1/doc/state/7/')
+        self.assertEqual(s.slug,         'pub')
+        self.assertEqual(s.type,         '/api/v1/doc/statetype/draft-iesg/')
+        self.assertEqual(s.used,         True)
 
     def test_document_states(self):
         dt = DataTracker()
         states = list(dt.document_states(statetype="draft-rfceditor"))
         self.assertEqual(len(states), 18)
-        self.assertEqual(states[ 0]['name'], 'AUTH')
-        self.assertEqual(states[ 1]['name'], 'AUTH48')
-        self.assertEqual(states[ 2]['name'], 'EDIT')
-        self.assertEqual(states[ 3]['name'], 'IANA')
-        self.assertEqual(states[ 4]['name'], 'IESG')
-        self.assertEqual(states[ 5]['name'], 'ISR')
-        self.assertEqual(states[ 6]['name'], 'ISR-AUTH')
-        self.assertEqual(states[ 7]['name'], 'REF')
-        self.assertEqual(states[ 8]['name'], 'RFC-EDITOR')
-        self.assertEqual(states[ 9]['name'], 'TO')
-        self.assertEqual(states[10]['name'], 'MISSREF')
-        self.assertEqual(states[11]['name'], 'AUTH48-DONE')
-        self.assertEqual(states[12]['name'], 'AUTH48-DONE')
-        self.assertEqual(states[13]['name'], 'EDIT')
-        self.assertEqual(states[14]['name'], 'IANA')
-        self.assertEqual(states[15]['name'], 'IESG')
-        self.assertEqual(states[16]['name'], 'ISR-AUTH')
-        self.assertEqual(states[17]['name'], 'Pending')
+        self.assertEqual(states[ 0].name, 'AUTH')
+        self.assertEqual(states[ 1].name, 'AUTH48')
+        self.assertEqual(states[ 2].name, 'EDIT')
+        self.assertEqual(states[ 3].name, 'IANA')
+        self.assertEqual(states[ 4].name, 'IESG')
+        self.assertEqual(states[ 5].name, 'ISR')
+        self.assertEqual(states[ 6].name, 'ISR-AUTH')
+        self.assertEqual(states[ 7].name, 'REF')
+        self.assertEqual(states[ 8].name, 'RFC-EDITOR')
+        self.assertEqual(states[ 9].name, 'TO')
+        self.assertEqual(states[10].name, 'MISSREF')
+        self.assertEqual(states[11].name, 'AUTH48-DONE')
+        self.assertEqual(states[12].name, 'AUTH48-DONE')
+        self.assertEqual(states[13].name, 'EDIT')
+        self.assertEqual(states[14].name, 'IANA')
+        self.assertEqual(states[15].name, 'IESG')
+        self.assertEqual(states[16].name, 'ISR-AUTH')
+        self.assertEqual(states[17].name, 'Pending')
 
     def test_document_state_types(self):
         dt = DataTracker()

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -44,7 +44,9 @@
 #   RFC 6359 "Datatracker Extensions to Include IANA and RFC Editor Processing Information"
 #   RFC 7760 "Statement of Work for Extensions to the IETF Datatracker for Author Statistics"
 
-from typing import List, Optional, Tuple, Dict, Iterator
+from typing      import List, Optional, Tuple, Dict, Iterator
+from dataclasses import dataclass
+from pavlova     import Pavlova
 
 import datetime
 import glob
@@ -52,6 +54,24 @@ import json
 import requests
 import unittest
 import re
+
+# =================================================================================================================================
+# A class to represent a Person:
+
+@dataclass
+class Person:
+    resource_uri    : str
+    id              : int
+    name            : str
+    name_from_draft : str
+    ascii           : str
+    ascii_short     : Optional[str]
+    user            : str
+    time            : str
+    photo           : str
+    photo_thumb     : str
+    biography       : str
+    consent         : bool
 
 # =================================================================================================================================
 # A class to represent the datatracker:
@@ -109,7 +129,7 @@ class DataTracker:
             email : the email address to lookup
 
         Returns:
-            A Dict containing the same fields as the person() method.
+            A Person object
         """
         return self.person("/api/v1/person/email/" + email + "/")
 
@@ -122,26 +142,14 @@ class DataTracker:
             person_uri : a URI of the form "/api/v1/person/person/20209/" or "api/v1/person/email/csp@csperkins.org/"
 
         Returns:
-            A Dict containing the following fields:
-                "resource_uri"    -- A URI representing this resource
-                "id"              -- A unique identifier for the person
-                "name"            -- 
-                "name_from_draft" -- 
-                "ascii"           -- 
-                "ascii_short"     -- 
-                "user"            -- 
-                "time"            -- 
-                "photo"           -- URL for a full size photo
-                "photo_thumb"     -- URL for a thumbnail photo
-                "biography"       -- Biography of the person
-                "consent"         -- 
+            A Person object
         """
         assert person_uri.startswith("/api/v1/person/")
         assert person_uri.endswith("/")
         if person_uri.startswith("/api/v1/person/person/"):
             response = self.session.get(self.base_url + person_uri, verify=True)
             if response.status_code == 200:
-                return response.json()
+                return Pavlova().from_mapping(response.json(), Person)
             else:
                 return None
         elif person_uri.startswith("/api/v1/person/email/"):
@@ -688,29 +696,29 @@ class TestDatatracker(unittest.TestCase):
     def test_person_from_email(self):
         dt = DataTracker()
         p  = dt.person_from_email("csp@csperkins.org")
-        self.assertEqual(p["resource_uri"], "/api/v1/person/person/20209/")
+        self.assertEqual(p.resource_uri, "/api/v1/person/person/20209/")
 
 
     def test_person_person(self):
         dt = DataTracker()
         p  = dt.person("/api/v1/person/person/20209/")
-        self.assertEqual(p["id"],              20209)
-        self.assertEqual(p["resource_uri"],    "/api/v1/person/person/20209/")
-        self.assertEqual(p["name"],            "Colin Perkins")
-        self.assertEqual(p["name_from_draft"], "Colin Perkins")
-        self.assertEqual(p["ascii"],           "Colin Perkins")
-        self.assertEqual(p["ascii_short"],     None)
-        self.assertEqual(p["user"],            "")
-        self.assertEqual(p["time"],            "2012-02-26T00:03:54")
-        self.assertEqual(p["photo"],           "https://www.ietf.org/lib/dt/media/photo/Colin-Perkins-sm.jpg")
-        self.assertEqual(p["photo_thumb"],     "https://www.ietf.org/lib/dt/media/photo/Colin-Perkins-sm_PMIAhXi.jpg")
-        self.assertEqual(p["biography"],       "Colin Perkins is a Senior Lecturer (Associate Professor) in the School of Computing Science at the University of Glasgow. His research interests are on transport protocols for real-time and interactive multimedia, and on network protocol design, implementation, and specification. He’s been a participant in the IETF and IRTF since 1996, working primarily in the transport area where he co-chairs the RMCAT working group and is a past chair of the AVT and MMUSIC working groups, and in related IRTF research groups. He proposed and co-chaired the first Applied Networking Research Workshop (ANRW), and has been a long-term participant in the Applied Networking Research Prize (ANRP) awarding committee. He received his BEng in Electronic Engineering in 1992, and my PhD in 1996, both from the Department of Electronics at the University of York.")
-        self.assertEqual(p["consent"],         True)
+        self.assertEqual(p.id,              20209)
+        self.assertEqual(p.resource_uri,    "/api/v1/person/person/20209/")
+        self.assertEqual(p.name,            "Colin Perkins")
+        self.assertEqual(p.name_from_draft, "Colin Perkins")
+        self.assertEqual(p.ascii,           "Colin Perkins")
+        self.assertEqual(p.ascii_short,     None)
+        self.assertEqual(p.user,            "")
+        self.assertEqual(p.time,            "2012-02-26T00:03:54")
+        self.assertEqual(p.photo,           "https://www.ietf.org/lib/dt/media/photo/Colin-Perkins-sm.jpg")
+        self.assertEqual(p.photo_thumb,     "https://www.ietf.org/lib/dt/media/photo/Colin-Perkins-sm_PMIAhXi.jpg")
+        self.assertEqual(p.biography,       "Colin Perkins is a Senior Lecturer (Associate Professor) in the School of Computing Science at the University of Glasgow. His research interests are on transport protocols for real-time and interactive multimedia, and on network protocol design, implementation, and specification. He’s been a participant in the IETF and IRTF since 1996, working primarily in the transport area where he co-chairs the RMCAT working group and is a past chair of the AVT and MMUSIC working groups, and in related IRTF research groups. He proposed and co-chaired the first Applied Networking Research Workshop (ANRW), and has been a long-term participant in the Applied Networking Research Prize (ANRP) awarding committee. He received his BEng in Electronic Engineering in 1992, and my PhD in 1996, both from the Department of Electronics at the University of York.")
+        self.assertEqual(p.consent,         True)
 
     def test_person_email(self):
         dt = DataTracker()
         p  = dt.person("/api/v1/person/email/csp@csperkins.org/")
-        self.assertEqual(p["resource_uri"],    "/api/v1/person/person/20209/")
+        self.assertEqual(p.resource_uri,    "/api/v1/person/person/20209/")
 
 
 #    def test_people(self):

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -74,6 +74,19 @@ class Person:
     consent         : bool
 
 # =================================================================================================================================
+# A class to represent an Email:
+
+@dataclass
+class Email:
+    resource_uri : str
+    address      : str
+    person       : str
+    time         : str
+    origin       : str
+    primary      : bool
+    active       : bool
+
+# =================================================================================================================================
 # A class to represent the datatracker:
 
 class DataTracker:
@@ -116,7 +129,7 @@ class DataTracker:
         """
         response = self.session.get(self.base_url + "/api/v1/person/email/" + email + "/", verify=True)
         if response.status_code == 200:
-            return response.json()
+            return Pavlova().from_mapping(response.json(), Email)
         else:
             return None
 
@@ -684,13 +697,13 @@ class TestDatatracker(unittest.TestCase):
     def test_email(self):
         dt = DataTracker()
         e  = dt.email("csp@csperkins.org")
-        self.assertEqual(e["resource_uri"], "/api/v1/person/email/csp@csperkins.org/")
-        self.assertEqual(e["address"],      "csp@csperkins.org")
-        self.assertEqual(e["person"],       "/api/v1/person/person/20209/")
-        self.assertEqual(e["time"],         "1970-01-01T23:59:59")
-        self.assertEqual(e["origin"],       "author: draft-ietf-tsvwg-transport-encrypt")
-        self.assertEqual(e["primary"],      True)
-        self.assertEqual(e["active"],       True)
+        self.assertEqual(e.resource_uri, "/api/v1/person/email/csp@csperkins.org/")
+        self.assertEqual(e.address,      "csp@csperkins.org")
+        self.assertEqual(e.person,       "/api/v1/person/person/20209/")
+        self.assertEqual(e.time,         "1970-01-01T23:59:59")
+        self.assertEqual(e.origin,       "author: draft-ietf-tsvwg-transport-encrypt")
+        self.assertEqual(e.primary,      True)
+        self.assertEqual(e.active,       True)
 
 
     def test_person_from_email(self):

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -433,11 +433,7 @@ class DataTracker:
         document_states().
 
         Returns:
-           A sequence of dicts, each containing the following fields:
-              resource_uri -- The URI representing this state
-              label        -- A label for the state
-              slug         -- A short name for the state
-
+           A sequence of StateType objects
         """
         api_url   = "/api/v1/doc/statetype/"
         while api_url != None:

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -427,9 +427,22 @@ class DataTracker:
 
 
     def document_from_std(self, std: str):
-        # FIXME: implement this
-        raise NotImplementedError
+        """
+        Returns the document that became the specified STD.
 
+        Parameters:
+            std -- The STD to lookup, in the form "std68" or "STD68"
+
+        Returns:
+            A Document object
+        """
+        assert std.lower().startswith("std")
+        url  = self.base_url + "/api/v1/doc/docalias/" + std.lower() + "/"
+        response = self.session.get(url, verify=True)
+        if response.status_code == 200:
+            return self.document(response.json()['document'])
+        else:
+            return None
 
     # Datatracker API endpoints returning information about document states:
     # * https://datatracker.ietf.org/api/v1/doc/state/                           - Types of state a document can be in
@@ -919,8 +932,9 @@ class TestDatatracker(unittest.TestCase):
         self.assertEqual(d.resource_uri, "/api/v1/doc/document/draft-sheffer-rfc6982bis/")
 
     def test_document_from_std(self):
-        # FIXME: implement tests
-        raise NotImplementedError
+        dt = DataTracker()
+        d  = dt.document_from_std("std68")
+        self.assertEqual(d.resource_uri, "/api/v1/doc/document/draft-crocker-rfc4234bis/")
 
     def test_document_state(self):
         dt = DataTracker()

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -412,7 +412,7 @@ class DataTracker:
         Returns the document that became the specified BCP.
 
         Parameters:
-            rfc -- The RFC to lookup, in the form "bcp205" or "BCP205"
+            bcp -- The BCP to lookup, in the form "bcp205" or "BCP205"
 
         Returns:
             A Document object

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -1005,8 +1005,15 @@ class TestDatatracker(unittest.TestCase):
         raise NotImplementedError
 
     def test_document_type(self):
-        # FIXME: implement tests
-        raise NotImplementedError
+        dt      = DataTracker()
+        doctype = dt.document_type("/api/v1/name/doctypename/draft/")
+        self.assertEqual(doctype.resource_uri, "/api/v1/name/doctypename/draft/")
+        self.assertEqual(doctype.name,         "Draft")
+        self.assertEqual(doctype.used,         True)
+        self.assertEqual(doctype.prefix,       "draft")
+        self.assertEqual(doctype.slug,         "draft")
+        self.assertEqual(doctype.desc,         "")
+        self.assertEqual(doctype.order,        0)
 
     def test_document_types(self):
         dt    = DataTracker()

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -744,7 +744,6 @@ class DataTracker:
 
     def groups(self, since="1970-01-01T00:00:00", until="2038-01-19T03:14:07", name_contains=None):
         # FIXME: add documentation
-        # FIXME: no tests for this
         """
         A generator that returns Group objects representing all groups recorded
         in the datatracker. The since and until parameters can be used to contrain
@@ -1142,11 +1141,14 @@ class TestDatatracker(unittest.TestCase):
         self.assertEqual(group.id, 941)
 
     def test_groups(self):
-        # FIXME: implement tests
-        raise NotImplementedError
+        dt = DataTracker()
+        # FIXME: split into two tests? _timerange, and _namecontains -- testing without parameters not practical
+        groups = list(dt.groups(since="2019-01-01T00:00:00", until="2019-01-31T23:59:59"))
+        self.assertEqual(len(groups),  2)
+        self.assertEqual(groups[0].id, 1897)
+        self.assertEqual(groups[1].id, 2220)
 
 if __name__ == '__main__':
-    #TestDatatracker().test_group()
     unittest.main()
 
 # =================================================================================================================================


### PR DESCRIPTION
Uses [Pavlova](https://medium.com/freelancer-engineering/introducing-pavlova-a-new-python-deserialization-library-47da000268e5) to deserialise JSON objects, allowing these to be returned instead of dicts. Also implements some of the outstanding methods (and corresponding tests).